### PR TITLE
add pagination to collections

### DIFF
--- a/cabby.go
+++ b/cabby.go
@@ -13,6 +13,8 @@ import (
 )
 
 const (
+	cabbyTaxiiNamespace = "15e011d3-bcec-4f41-92d0-c6fc22ab9e45"
+
 	// StixContentType20 represents a stix 2.0 content type
 	StixContentType20 = "application/vnd.oasis.stix+json; version=2.0"
 	// StixContentType represents a stix 2 content type
@@ -166,8 +168,6 @@ func NewID() (ID, error) {
 	return ID{id}, err
 }
 
-const cabbyTaxiiNamespace = "15e011d3-bcec-4f41-92d0-c6fc22ab9e45"
-
 // IDFromString takes a uuid string and coerces to ID
 func IDFromString(s string) (ID, error) {
 	id, err := uuid.FromString(s)
@@ -274,11 +274,6 @@ func (r *Range) String() string {
 	}
 
 	return s
-}
-
-// RangeInjector is implemented in the data store for resources that can be paginated
-type RangeInjector interface {
-	WithPagination(query string) string
 }
 
 // Valid returns whether the range is valid or not

--- a/cabby_test.go
+++ b/cabby_test.go
@@ -38,6 +38,67 @@ func TestNewCollection(t *testing.T) {
 	}
 }
 
+func TestNewRange(t *testing.T) {
+	invalidRange := Range{First: -1, Last: -1}
+
+	tests := []struct {
+		input       string
+		resultRange Range
+		isError     bool
+	}{
+		{"items 0-10", Range{First: 0, Last: 10}, false},
+		{"items 0 10", invalidRange, true},
+		{"items 10", invalidRange, true},
+		{"", invalidRange, false},
+	}
+
+	for _, test := range tests {
+		result, err := NewRange(test.input)
+		if result != test.resultRange {
+			t.Error("Got:", result, "Expected:", test.resultRange)
+		}
+
+		if err != nil && test.isError == false {
+			t.Error("Got:", err, "Expected: no error")
+		}
+	}
+}
+
+func TestRangeString(t *testing.T) {
+	tests := []struct {
+		testRange Range
+		expected  string
+	}{
+		{Range{First: 0, Last: 0}, "items 0-0"},
+		{Range{First: 0, Last: 0, Total: 50}, "items 0-0/50"},
+	}
+
+	for _, test := range tests {
+		result := test.testRange.String()
+		if result != test.expected {
+			t.Error("Got:", result, "Expected:", test.expected)
+		}
+	}
+}
+
+func TestRangeValid(t *testing.T) {
+	tests := []struct {
+		testRange Range
+		expected  bool
+	}{
+		{Range{First: 1, Last: 0}, false},
+		{Range{First: 0, Last: 0}, true},
+		{Range{First: 0, Last: -1}, false},
+	}
+
+	for _, test := range tests {
+		result := test.testRange.Valid()
+		if result != test.expected {
+			t.Error("Got:", result, "Expected:", test.expected)
+		}
+	}
+}
+
 func TestParseConfig(t *testing.T) {
 	cs := Configs{}.Parse("config/cabby.example.json")
 

--- a/cmd/cabby-cli
+++ b/cmd/cabby-cli
@@ -32,7 +32,7 @@ while getopts ":c:hp:u:a" opt; do
       usage
       ;;
     p)
-      PASS=$(printf "$OPTARG" | sha256sum | cut -d '-' -f 1 | xargs)
+      PASS=$(printf "$OPTARG" | shasum -a 256 | cut -d '-' -f 1 | xargs)
       ;;
     u)
       CABBY_USER="$OPTARG"
@@ -63,21 +63,21 @@ if [ -z $PASS ]; then
   exit 1
 fi
 
-DB_PATH=$(jq .$CABBY_ENV.data_store.path $CONFIG_PATH | sed 's/"//g')
-DB_DIR=$(dirname $DB_PATH)
+DB_PATH="$(jq .$CABBY_ENV.data_store.path $CONFIG_PATH | sed 's/\"//g')"
+DB_DIR="$(dirname $DB_PATH)"
 
 mkdir -p "$DB_DIR"
 sqlite3 "$DB_PATH" ".read $CABBY_SCHEMA"
 
 # set up user
 echo "Creating a user"
-sqlite3 $DB_PATH "insert into taxii_user (email) values('${CABBY_USER}')"
+sqlite3 $DB_PATH "insert into taxii_user (email) values('$CABBY_USER')"
 if [ $USER_ADMIN -eq 1 ]; then
   echo "  Making user admin"
-  sqlite3 $DB_PATH "update taxii_user set can_admin = 1 where email = '${CABBY_USER}'"
+  sqlite3 $DB_PATH "update taxii_user set can_admin = 1 where email = '$CABBY_USER'"
 fi
 
-sqlite3 $DB_PATH "insert into taxii_user_pass (email, pass) values('${CABBY_USER}', '${PASS}')"
+sqlite3 $DB_PATH "insert into taxii_user_pass (email, pass) values('$CABBY_USER', '$PASS')"
 
 # set up discovery
 sqlite3 $DB_PATH "
@@ -95,34 +95,37 @@ API_ROOT=cabby_test_root
 sqlite3 $DB_PATH "
 insert into taxii_api_root (id, api_root_path, title, description, versions, max_content_length) values (
   'testId',
-  '${API_ROOT}',
+  '$API_ROOT',
   'a title',
   'a description',
   'application/vnd.oasis.stix+json; version=2.0',
   8388608 /* 8 MB */
 )"
 
-# set up collection
-echo "Creating a collection"
-COLLECTION_ID=352abc04-a474-4e22-9f4d-944ca508e68c
+# set up collections
+echo "Creating a collections"
+COLLECTION_IDS="352abc04-a474-4e22-9f4d-944ca508e68c 40aabc04-a474-4e02-cf4d-a44ca901e68c"
 
-sqlite3 $DB_PATH "
-insert into taxii_collection (id, api_root_path, title, description, media_types) values (
-  '${COLLECTION_ID}',
-  '${API_ROOT}',
-  'a test collection',
-  'a test collection description',
-  ''
-)"
+for id in $COLLECTION_IDS; do
+  echo "  Creating collection $id"
+  sqlite3 $DB_PATH "
+  insert into taxii_collection (id, api_root_path, title, description, media_types) values (
+    '$id',
+    '$API_ROOT',
+    'a test collection',
+    'a test collection description',
+    ''
+  )"
 
-echo "Associate user to collection"
-sqlite3 $DB_PATH "
-insert into taxii_user_collection (email, collection_id, can_write, can_read) values (
-  '${CABBY_USER}',
-  '${COLLECTION_ID}',
-  1,
-  1
-)"
+  echo "  Associate user to collection $id"
+  sqlite3 $DB_PATH "
+  insert into taxii_user_collection (email, collection_id, can_write, can_read) values (
+    '$CABBY_USER',
+    '$id',
+    1,
+    1
+  )"
+done
 
 if [ "$CABBY_ENV" == "production" ]; then
   echo "CABBY_ENVIRONMENT is production, changing ownership of $DB_PATH to cabby"

--- a/http/collections_test.go
+++ b/http/collections_test.go
@@ -3,7 +3,10 @@ package http
 import (
 	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	cabby "github.com/pladdy/cabby2"
@@ -30,12 +33,91 @@ func TestCollectionsHandlerGet(t *testing.T) {
 	}
 }
 
+func TestCollectionsHandlerGetRange(t *testing.T) {
+	tests := []struct {
+		first    int
+		last     int
+		expected int
+	}{
+		{0, 0, 1},
+		{0, 9, 10},
+	}
+
+	for _, test := range tests {
+		// set up mock service
+		cs := mockCollectionService()
+		cs.CollectionsFn = func(user, apiRootPath string, cr *cabby.Range) (cabby.Collections, error) {
+			collections := cabby.Collections{}
+			for i := 0; i < test.expected; i++ {
+				collections.Collections = append(collections.Collections, cabby.Collection{})
+			}
+
+			cr.Total = int64(test.expected)
+			return collections, nil
+		}
+		h := CollectionsHandler{CollectionService: cs}
+
+		// set up request
+		req := withAuthentication(newRequest("GET", testCollectionsURL, nil))
+		req.Header.Set("Range", "items "+strconv.Itoa(test.first)+"-"+strconv.Itoa(test.last))
+
+		res := httptest.NewRecorder()
+		h.Get(res, req)
+
+		body, _ := ioutil.ReadAll(res.Body)
+
+		var collections cabby.Collections
+		err := json.Unmarshal([]byte(body), &collections)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.Code != http.StatusPartialContent {
+			t.Error("Got:", res.Code, "Expected:", http.StatusPartialContent)
+		}
+
+		if len(collections.Collections) != test.expected {
+			t.Error("Got:", len(collections.Collections), "Expected:", test.expected)
+		}
+
+		ra := cabby.Range{First: int64(test.first), Last: int64(test.last), Total: int64(test.expected)}
+		if res.Header().Get("Content-Range") != ra.String() {
+			t.Error("Got:", res.Header().Get("Content-Range"), "Expected:", ra.String())
+		}
+	}
+}
+
+func TestCollectionsHandlerGetInvalidRange(t *testing.T) {
+	tests := []struct {
+		rangeString    string
+		expectedStatus int
+	}{
+		{"items invalid", http.StatusRequestedRangeNotSatisfiable},
+		{"items 0-0", http.StatusPartialContent},
+	}
+
+	h := CollectionsHandler{CollectionService: mockCollectionService()}
+
+	for _, test := range tests {
+		// set up request
+		req := withAuthentication(newRequest("GET", testCollectionsURL, nil))
+		req.Header.Set("Range", test.rangeString)
+
+		res := httptest.NewRecorder()
+		h.Get(res, req)
+
+		if res.Code != test.expectedStatus {
+			t.Error("Got:", res.Code, "Expected:", test.expectedStatus)
+		}
+	}
+}
+
 func TestCollectionsHandlerGetFailures(t *testing.T) {
 	expected := cabby.Error{
 		Title: "Internal Server Error", Description: "Collection failure", HTTPStatus: http.StatusInternalServerError}
 
 	cs := mockCollectionService()
-	cs.CollectionsFn = func(user, apiRootPath string) (cabby.Collections, error) {
+	cs.CollectionsFn = func(user, apiRootPath string, cr *cabby.Range) (cabby.Collections, error) {
 		return cabby.Collections{}, errors.New(expected.Description)
 	}
 
@@ -60,7 +142,7 @@ func TestCollectionsHandlerGetFailures(t *testing.T) {
 
 func TestCollectionsHandlerGetNoCollections(t *testing.T) {
 	cs := mockCollectionService()
-	cs.CollectionsFn = func(user, apiRoot string) (cabby.Collections, error) {
+	cs.CollectionsFn = func(user, apiRoot string, cr *cabby.Range) (cabby.Collections, error) {
 		return cabby.Collections{}, nil
 	}
 

--- a/http/helper_test.go
+++ b/http/helper_test.go
@@ -177,7 +177,9 @@ func mockCollectionService() tester.CollectionService {
 	cs.CollectionFn = func(user, collectionID, apiRootPath string) (cabby.Collection, error) {
 		return tester.Collection, nil
 	}
-	cs.CollectionsFn = func(user, apiRootPath string) (cabby.Collections, error) { return tester.Collections, nil }
+	cs.CollectionsFn = func(user, apiRootPath string, cr *cabby.Range) (cabby.Collections, error) {
+		return tester.Collections, nil
+	}
 	cs.CollectionsInAPIRootFn = func(apiRootPath string) (cabby.CollectionsInAPIRoot, error) {
 		return tester.CollectionsInAPIRoot, nil
 	}

--- a/http/responses.go
+++ b/http/responses.go
@@ -11,10 +11,7 @@ import (
 func resourceToJSON(v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"value": v,
-			"error": err,
-		}).Panic("Can't convert to JSON")
+		log.WithFields(log.Fields{"value": v, "error": err}).Panic("Can't convert to JSON")
 	}
 	return string(b)
 }
@@ -29,8 +26,8 @@ func writeContent(w http.ResponseWriter, contentType, content string) {
 	io.WriteString(w, content)
 }
 
-// func writePartialContent(w http.ResponseWriter, contentType, content string) {
-// 	w.Header().Set("Content-Type", contentType)
-// 	w.WriteHeader(http.StatusPartialContent)
-// 	io.WriteString(w, content)
-// }
+func writePartialContent(w http.ResponseWriter, contentType, content string) {
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(http.StatusPartialContent)
+	io.WriteString(w, content)
+}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -123,14 +123,8 @@ func TestSetupServerLogging(t *testing.T) {
 		log.SetOutput(os.Stderr)
 	}()
 
-	// set up test
-	ds := tester.DataStore{}
-	ds.UserServiceFn = func() tester.UserService {
-		return tester.UserService{}
-	}
-
 	handler := http.NewServeMux()
-	_ = setupServer(ds, handler, cabby.Config{Port: 1234})
+	_ = setupServer(mockDataStore(), handler, cabby.Config{Port: 1234})
 
 	type expectedLog struct {
 		Time  string
@@ -152,14 +146,8 @@ func TestSetupServerLogging(t *testing.T) {
 }
 
 func TestSetupServerSettings(t *testing.T) {
-	// set up test
-	ds := tester.DataStore{}
-	ds.UserServiceFn = func() tester.UserService {
-		return tester.UserService{}
-	}
-
 	handler := http.NewServeMux()
-	server := setupServer(ds, handler, cabby.Config{Port: 1234})
+	server := setupServer(mockDataStore(), handler, cabby.Config{Port: 1234})
 
 	// set server settings
 	expectedAddr := ":1234"

--- a/sqlite/helper_test.go
+++ b/sqlite/helper_test.go
@@ -37,7 +37,7 @@ func createAPIRoot(ds *DataStore) {
 	tx.Commit()
 }
 
-func createCollection(ds *DataStore) {
+func createCollection(ds *DataStore, id string) {
 	c := tester.Collection
 
 	tx, err := ds.DB.Begin()
@@ -53,7 +53,7 @@ func createCollection(ds *DataStore) {
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(c.ID.String(), c.APIRootPath, c.Title, c.Description, strings.Join(c.MediaTypes, ","))
+	_, err = stmt.Exec(id, c.APIRootPath, c.Title, c.Description, strings.Join(c.MediaTypes, ","))
 	if err != nil {
 		tester.Error.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func createCollection(ds *DataStore) {
 	}
 	defer stmt.Close()
 
-	_, err = stmt.Exec(tester.UserEmail, c.ID.String(), c.CanRead, c.CanWrite)
+	_, err = stmt.Exec(tester.UserEmail, id, c.CanRead, c.CanWrite)
 	if err != nil {
 		tester.Error.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func setupSQLite() {
 	createUser(ds)
 	createDiscovery(ds)
 	createAPIRoot(ds)
-	createCollection(ds)
+	createCollection(ds, tester.Collection.ID.String())
 	createObject(ds)
 }
 

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -150,3 +150,8 @@ func (s *DataStore) writeOperation(query string) (tx *sql.Tx, stmt *sql.Stmt, er
 	}
 	return
 }
+
+// WithPagination for SQLite uses limit/offset to paginate
+func WithPagination(query string) string {
+	return query + "\nlimit ? offset ?"
+}

--- a/sqlite/sqllite_test.go
+++ b/sqlite/sqllite_test.go
@@ -30,6 +30,15 @@ func TestDataStoreClose(t *testing.T) {
 	s.Close()
 }
 
+func TestRangeInjectorWithPagination(t *testing.T) {
+	result := WithPagination("select 1")
+	expected := "select 1\nlimit ? offset ?"
+
+	if result != expected {
+		t.Error("Got:", result, "Expected:", expected)
+	}
+}
+
 func TestSQLiteBatchWriteSmall(t *testing.T) {
 	setupSQLite()
 	ds := testDataStore()

--- a/tester/services.go
+++ b/tester/services.go
@@ -89,7 +89,7 @@ func (s APIRootService) APIRoots() ([]cabby.APIRoot, error) {
 // CollectionService is a mock implementation
 type CollectionService struct {
 	CollectionFn           func(user, collectionID, apiRootPath string) (cabby.Collection, error)
-	CollectionsFn          func(user, apiRootPath string) (cabby.Collections, error)
+	CollectionsFn          func(user, apiRootPath string, cr *cabby.Range) (cabby.Collections, error)
 	CollectionsInAPIRootFn func(apiRootPath string) (cabby.CollectionsInAPIRoot, error)
 }
 
@@ -99,8 +99,8 @@ func (s CollectionService) Collection(user, collectionID, apiRootPath string) (c
 }
 
 // Collections is a mock implementation
-func (s CollectionService) Collections(user, apiRootPath string) (cabby.Collections, error) {
-	return s.CollectionsFn(user, apiRootPath)
+func (s CollectionService) Collections(user, apiRootPath string, cr *cabby.Range) (cabby.Collections, error) {
+	return s.CollectionsFn(user, apiRootPath, cr)
 }
 
 // CollectionsInAPIRoot is a mock implementation


### PR DESCRIPTION
#### What's new
- add pagination to collections end point
- removed interpolation this time; using parameter passing
- add 2 collections with `make dev-db`
- createCollection is more generic in sqlite package for testing purposes

#### How to test
`make test`