### PR TITLE
Fix objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ build/debian/var/cabby/schema.sql: build/debian/var/cabby/
 build-debian: config build/debian/etc/cabby/cabby.json build/debian/var/cabby/schema.sql
 	vagrant up
 	@echo Magic has happend to make a debian...
+	vagrant destroy -f
 
 clean:
 	rm -rf db/
@@ -127,7 +128,7 @@ reportcard: fmt
 	go vet
 
 run:
-	go run cmd/cabby/main.go -config config/cabby.json
+	go run $(BUILD_TAGS) cmd/cabby/main.go -config config/cabby.json
 
 run-cli:
 	go run $(CLI_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build/debian/usr/bin/cabby build/debian/usr/bin/cabby-cli
+.PHONY: all build build/debian/usr/bin/cabby build/debian/usr/bin/cabby-cli build/debian/var/cabby/schema.sql
 .PHONY: clean clean-cli cmd/cabby-cli/cabby-cli config cover cover-html db/cabby.db reportcard run run-log
 .PHONY: test test-failures test test-run
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ curl -sk -basic -u test@cabby.com:test-password -H 'Accept: application/vnd.oasi
 
 ## Resources
 - OASIS Doc: https://oasis-open.github.io/cti-documentation/resources
-- TAXII 2.0 Spec: https://docs.google.com/document/d/1Jv9ICjUNZrOnwUXtenB1QcnBLO35RnjQcJLsa1mGSkI
-- STIX 2.0 Spec: https://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part1-stix-core.html
+  - TAXII 2.0 Spec: https://docs.google.com/document/d/1Jv9ICjUNZrOnwUXtenB1QcnBLO35RnjQcJLsa1mGSkI
+  - STIX 2.0 Spec: https://docs.oasis-open.org/cti/stix/v2.0/stix-v2.0-part1-stix-core.html
+  - STIX/TAXII Graphics: https://freetaxii.github.io/
 - TLS in Golang Examples: https://gist.github.com/denji/12b3a568f092ab951456
-- Perfect SSL Labs Score Article: https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go
+  - Perfect SSL Labs Score Article: https://blog.bracebin.com/achieving-perfect-ssl-labs-score-with-go

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In the above example, new collections were added.  Kill the server (CTRL+C) and 
 
 Now post a bundle of STIX 2.0 data:
 ```sh
-curl -sk -basic -u test@cabby.com:test-password -H 'Accept: application/vnd.oasis.stix+json' -X POST 'https://localhost:1234/cabby_test_root/collections/352abc04-a474-4e22-9f4d-944ca508e68c/objects/' -d @sqlite/testdata/malware_bundle.json | jq .
+curl -sk -basic -u test@cabby.com:test-password -H 'Accept: application/vnd.oasis.taxii+json' -H 'Content-Type: application/vnd.oasis.stix+json' -X POST 'https://localhost:1234/cabby_test_root/collections/352abc04-a474-4e22-9f4d-944ca508e68c/objects/' -d @sqlite/testdata/malware_bundle.json | jq .
 ```
 
 #### Check status

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,9 +29,10 @@ Vagrant.configure("2") do |config|
       export GOPATH=/opt/go
       export PATH=/usr/lib/go-1.10/bin/:$PATH
 
-      mkdir -p /opt/go/src/cabby
-      cp -r /vagrant/* /opt/go/src/cabby
-      cd /opt/go/src/cabby
+      SRC_DIR=/opt/go/src/github.com/pladdy/cabby2
+      mkdir -p $SRC_DIR
+      cp -r /vagrant/* $SRC_DIR
+      cd $SRC_DIR
 
       make && make test && make build
       fpm -f \

--- a/cmd/cabby/main.go
+++ b/cmd/cabby/main.go
@@ -10,6 +10,8 @@ import (
 )
 
 func main() {
+	log.SetLevel(log.InfoLevel)
+
 	var configPath = flag.String("config", cabby.DefaultProductionConfig, "path to cabby config file")
 	flag.Parse()
 

--- a/http/handlers_test.go
+++ b/http/handlers_test.go
@@ -73,7 +73,7 @@ func TestRequestHandlerRouteRequest(t *testing.T) {
 	}
 }
 
-func TestWithAcceptType(t *testing.T) {
+func TestWithMimeType(t *testing.T) {
 	tests := []struct {
 		acceptedHeader string
 		acceptHeader   string
@@ -98,7 +98,7 @@ func TestWithAcceptType(t *testing.T) {
 			accept := r.Header.Get("Accept")
 			io.WriteString(w, fmt.Sprintf("Accept Header: %v", accept))
 		}
-		testHandler = WithAcceptType(testHandler, test.acceptedHeader)
+		testHandler = WithMimeType(testHandler, "Accept", test.acceptedHeader)
 
 		req := httptest.NewRequest("GET", "/test", nil)
 		req.Header.Add("Accept", test.acceptHeader)

--- a/http/helper_test.go
+++ b/http/helper_test.go
@@ -59,12 +59,12 @@ func attemptRequest(c *http.Client, r *http.Request) (*http.Response, error) {
 	return nil, errors.New("Failed to get request")
 }
 
-func callHandler(h http.HandlerFunc, req *http.Request) (int, string) {
+func callHandler(h http.HandlerFunc, req *http.Request) (int, string, http.Header) {
 	res := httptest.NewRecorder()
 	h(res, req)
 
 	body, _ := ioutil.ReadAll(res.Body)
-	return res.Code, string(body)
+	return res.Code, string(body), res.Header()
 }
 
 func getResponse(req *http.Request, server *httptest.Server) (*http.Response, error) {
@@ -76,11 +76,13 @@ func getResponse(req *http.Request, server *httptest.Server) (*http.Response, er
 // it returns the status code and response as a string
 func handlerTest(h http.HandlerFunc, method, url string, b *bytes.Buffer) (int, string) {
 	req := newRequest(method, url, b)
-	return callHandler(h, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	code, body, _ := callHandler(h, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	return code, body
 }
 
 func handlerTestNoAuth(h http.HandlerFunc, method, url string, b *bytes.Buffer) (int, string) {
-	return callHandler(h, newRequest(method, url, b))
+	code, body, _ := callHandler(h, newRequest(method, url, b))
+	return code, body
 }
 
 func lastLog(buf bytes.Buffer) string {

--- a/http/helper_test.go
+++ b/http/helper_test.go
@@ -88,6 +88,13 @@ func lastLog(buf bytes.Buffer) string {
 	return logs[len(logs)-1]
 }
 
+func newPostRequest(url string, b *bytes.Buffer) *http.Request {
+	req := newRequest("POST", url, b)
+	req.Header.Set("Accept", cabby.TaxiiContentType)
+	req.Header.Set("Content-Type", cabby.StixContentType)
+	return req
+}
+
 func newRequest(method, url string, b *bytes.Buffer) *http.Request {
 	if b != nil {
 		return httptest.NewRequest(method, url, b)

--- a/http/objects.go
+++ b/http/objects.go
@@ -124,8 +124,10 @@ func (h ObjectsHandler) Post(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", cabby.TaxiiContentType)
 	w.WriteHeader(http.StatusAccepted)
 	writeContent(w, cabby.TaxiiContentType, resourceToJSON(status))
+
 	go h.ObjectService.CreateBundle(r.Context(), bundle, takeCollectionID(r), status, h.StatusService)
 }
 

--- a/http/objects_test.go
+++ b/http/objects_test.go
@@ -55,7 +55,7 @@ func TestObjectsHandlerGet(t *testing.T) {
 	// call handler for object
 	req := newRequest("GET", testObjectURL, nil)
 	req.Header.Set("Accept", cabby.StixContentType)
-	status, body := callHandler(h.Get, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, body, _ := callHandler(h.Get, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != http.StatusOK {
 		t.Error("Got:", status, "Expected:", http.StatusOK)
@@ -87,7 +87,7 @@ func TestObjectsHandlerGet(t *testing.T) {
 	// call handler for objects
 	req = newRequest("GET", testObjectsURL, nil)
 	req.Header.Set("Accept", cabby.StixContentType)
-	status, body = callHandler(h.Get, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, body, _ = callHandler(h.Get, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != http.StatusOK {
 		t.Error("Got:", status, "Expected:", http.StatusOK)
@@ -354,10 +354,14 @@ func TestObjectsHandlerPost(t *testing.T) {
 	b := bytes.NewBuffer(bundle)
 
 	req := newPostRequest(testObjectURL, b)
-	status, body := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, body, headers := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != http.StatusAccepted {
 		t.Error("Got:", status, "Expected:", http.StatusAccepted)
+	}
+
+	if headers.Get("content-type") != cabby.TaxiiContentType {
+		t.Error("Got:", headers["content-type"], "Expected:", cabby.TaxiiContentType)
 	}
 
 	var result cabby.Status
@@ -378,7 +382,7 @@ func TestObjectsHandlerPostForbidden(t *testing.T) {
 	h := ObjectsHandler{ObjectService: mockObjectService()}
 
 	req := newPostRequest(testObjectsURL, nil)
-	status, _ := callHandler(h.Post, req)
+	status, _, _ := callHandler(h.Post, req)
 
 	if status != http.StatusForbidden {
 		t.Error("Got:", status, "Expected:", http.StatusForbidden)
@@ -393,7 +397,7 @@ func TestObjectsHandlerPostContentTooLarge(t *testing.T) {
 	b := bytes.NewBuffer(bundle)
 
 	req := newPostRequest(testObjectsURL, b)
-	status, _ := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, _, _ := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != http.StatusRequestEntityTooLarge {
 		t.Error("Got:", status, "Expected:", http.StatusRequestEntityTooLarge)
@@ -407,7 +411,7 @@ func TestObjectsHandlerPostInvalidBundle(t *testing.T) {
 	b := bytes.NewBuffer(bundle)
 
 	req := newPostRequest(testObjectsURL, b)
-	status, _ := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, _, _ := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != http.StatusBadRequest {
 		t.Error("Got:", status, "Expected:", http.StatusBadRequest)
@@ -422,7 +426,7 @@ func TestObjectsHandlerPostEmptyBundle(t *testing.T) {
 	b := bytes.NewBuffer(bundle)
 
 	req := newPostRequest(testObjectsURL, b)
-	status, _ := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, _, _ := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != http.StatusBadRequest {
 		t.Error("Got:", status, "Expected:", http.StatusBadRequest)
@@ -445,10 +449,14 @@ func TestObjectsPostStatusFail(t *testing.T) {
 	b := bytes.NewBuffer(bundle)
 
 	req := newPostRequest(testObjectsURL, b)
-	status, body := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
+	status, body, headers := callHandler(h.Post, req.WithContext(cabby.WithUser(req.Context(), tester.User)))
 
 	if status != expected.HTTPStatus {
 		t.Error("Got:", status, "Expected:", expected.HTTPStatus)
+	}
+
+	if headers.Get("content-type") != cabby.TaxiiContentType {
+		t.Error("Got:", headers["content-type"], "Expected:", cabby.TaxiiContentType)
 	}
 
 	var result cabby.Error

--- a/http/routes.go
+++ b/http/routes.go
@@ -24,13 +24,13 @@ func registerAPIRoots(ds cabby.DataStore, sm *http.ServeMux) {
 
 func registerAPIRoot(ah APIRootHandler, path string, sm *http.ServeMux) {
 	if path != "" {
-		registerRoute(sm, path, WithAcceptType(RouteRequest(ah), cabby.TaxiiContentType))
+		registerRoute(sm, path, WithMimeType(RouteRequest(ah), "Accept", cabby.TaxiiContentType))
 	}
 }
 
 func registerCollectionRoutes(ds cabby.DataStore, apiRoot cabby.APIRoot, sm *http.ServeMux) {
 	csh := CollectionsHandler{CollectionService: ds.CollectionService()}
-	registerRoute(sm, apiRoot.Path+"/collections", WithAcceptType(RouteRequest(csh), cabby.TaxiiContentType))
+	registerRoute(sm, apiRoot.Path+"/collections", WithMimeType(RouteRequest(csh), "Accept", cabby.TaxiiContentType))
 
 	ss := ds.StatusService()
 	oh := ObjectsHandler{
@@ -51,19 +51,19 @@ func registerCollectionRoutes(ds cabby.DataStore, apiRoot cabby.APIRoot, sm *htt
 		registerRoute(
 			sm,
 			apiRoot.Path+"/collections/"+collectionID.String(),
-			WithAcceptType(RouteRequest(ch), cabby.TaxiiContentType))
+			WithMimeType(RouteRequest(ch), "Accept", cabby.TaxiiContentType))
 		registerRoute(
 			sm,
 			apiRoot.Path+"/collections/"+collectionID.String()+"/objects",
-			WithAcceptType(RouteRequest(oh), cabby.StixContentType))
+			RouteRequest(oh))
 		registerRoute(
 			sm,
 			apiRoot.Path+"/collections/"+collectionID.String()+"/manifest",
-			WithAcceptType(RouteRequest(mh), cabby.TaxiiContentType))
+			WithMimeType(RouteRequest(mh), "Accept", cabby.TaxiiContentType))
 	}
 
 	sh := StatusHandler{StatusService: ss}
-	registerRoute(sm, apiRoot.Path+"/status", WithAcceptType(RouteRequest(sh), cabby.TaxiiContentType))
+	registerRoute(sm, apiRoot.Path+"/status", WithMimeType(RouteRequest(sh), "Accept", cabby.TaxiiContentType))
 }
 
 func registerRoute(sm *http.ServeMux, path string, h http.HandlerFunc) {

--- a/http/server.go
+++ b/http/server.go
@@ -16,7 +16,7 @@ func NewCabby(ds cabby.DataStore, c cabby.Config) *http.Server {
 	registerAPIRoots(ds, handler)
 
 	dh := DiscoveryHandler{DiscoveryService: ds.DiscoveryService(), Port: c.Port}
-	registerRoute(handler, "taxii", WithAcceptType(RouteRequest(dh), cabby.TaxiiContentType))
+	registerRoute(handler, "taxii", WithMimeType(RouteRequest(dh), "Accept", cabby.TaxiiContentType))
 
 	registerRoute(handler, "/", handleUndefinedRoute)
 

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -8,14 +8,16 @@ set -euo pipefail
 chmod 775 /usr/bin/cabby-certs
 
 # create db
-CABBY_SCHEMA="/var/cabby/schema.sql"
+CABBY_ROOT=/var/cabby
+CABBY_SCHEMA="$CABBY_ROOT/schema.sql"
 CONFIG_PATH="/etc/cabby/cabby.json"
 DB_PATH="$(jq .data_store.path $CONFIG_PATH | sed 's/\"//g')"
 mkdir -p "$(dirname $DB_PATH)"
 sqlite3 "$DB_PATH" ".read $CABBY_SCHEMA"
 
 # change ownership
-chown cabby:cabby $DB_PATH
+chown cabby:cabby -R $CABBY_ROOT
+chmod 664 $DB_PATH
 
 # warn the user
 echo "To finish setup:"

--- a/scripts/postinst
+++ b/scripts/postinst
@@ -14,6 +14,9 @@ DB_PATH="$(jq .data_store.path $CONFIG_PATH | sed 's/\"//g')"
 mkdir -p "$(dirname $DB_PATH)"
 sqlite3 "$DB_PATH" ".read $CABBY_SCHEMA"
 
+# change ownership
+chown cabby:cabby $DB_PATH
+
 # warn the user
 echo "To finish setup:"
 echo "  'sudo cabby-certs', or edit /etc/cabby/cabby.json to point to .crt and .key file"

--- a/scripts/setup-cabby
+++ b/scripts/setup-cabby
@@ -23,6 +23,7 @@ DISCOVERY_TITLE="test cabby server"
 TAXII_USER="test@cabby.com"
 TAXII_PASSWORD="test-password"
 
+# set up db
 DB_PATH="$(jq .data_store.path $CONFIG_PATH | sed 's/\"//g')"
 DB_DIR="$(dirname $DB_PATH)"
 mkdir -p "$DB_DIR"


### PR DESCRIPTION
#### What's new?
- on post objects, content-type is now set
- build-debian copies the repo to the go path src dir (so it's now used, herp derp)
- add validation of post objects (separate from Post())
- make mime type decorator generic
- fix database file ownership and file perms on install

#### How to test
`make test`